### PR TITLE
Catch IndexError in xviewwidget

### DIFF
--- a/projexui/widgets/xviewwidget/xviewwidget.py
+++ b/projexui/widgets/xviewwidget/xviewwidget.py
@@ -143,7 +143,7 @@ class XViewWidget(QtGui.QScrollArea):
             return focus_panel
         try:
             return panels[0]
-        except AttributeError:
+        except IndexError:
             return None
     
     def currentView(self):


### PR DESCRIPTION
It was catching AttributeError instead of IndexError for the line "return panels[0]"
